### PR TITLE
Added decorate helper, and hid action to maintain encapsulation.

### DIFF
--- a/lib/deckorator.rb
+++ b/lib/deckorator.rb
@@ -1,8 +1,11 @@
 require 'deckorator/version'
 require 'deckorator/delegator'
 require 'deckorator/finder'
+require 'active_support/concern'
 
 module Deckorator
+  extend ActiveSupport::Concern
+
   class << self
     def decorate(record)
       if record.kind_of?(Array) || record.respond_to?(:all)
@@ -15,6 +18,11 @@ module Deckorator
         decorate_object(record)
       end
     end
+  end
+
+  included do
+    helper_method :decorate if respond_to?(:helper_method)
+    hide_action :decorate if respond_to?(:hide_action)
   end
 
   private


### PR DESCRIPTION
Turns out this kinda needs to be a helper method too. Also runs `hide_action` on decorate so that the method doesn't travel down the controller tree(see explanation [here](http://yehudakatz.com/2009/06/11/rails-edge-architecture/)).

This should address #19- it turns `decorate/1` into a helper by default, without any additional danger.