### PR TITLE
Add undecorate support

### DIFF
--- a/lib/deckorator.rb
+++ b/lib/deckorator.rb
@@ -1,6 +1,7 @@
 require 'deckorator/version'
 require 'deckorator/delegator'
 require 'deckorator/finder'
+require 'deckorator/undecorator'
 require 'active_support/concern'
 
 module Deckorator
@@ -21,12 +22,16 @@ module Deckorator
   end
 
   included do
-    helper_method :decorate if respond_to?(:helper_method)
-    hide_action :decorate if respond_to?(:hide_action)
+    helper_method :decorate, :undecorate if respond_to?(:helper_method)
+    hide_action :decorate, :undecorate if respond_to?(:hide_action)
   end
 
   def decorate(record)
     Deckorator.decorate(record)
+  end
+
+  def undecorate(decorated_record)
+    decorated_record.try(:decorated_object)
   end
 
   private

--- a/lib/deckorator/undecorator.rb
+++ b/lib/deckorator/undecorator.rb
@@ -1,0 +1,11 @@
+require 'active_support/concern'
+
+module Deckorator
+  module Undecorator
+    extend ActiveSupport::Concern
+
+    def undecorate
+      decorated_object
+    end
+  end
+end

--- a/lib/generators/deckorator/install/templates/application_decorator.rb
+++ b/lib/generators/deckorator/install/templates/application_decorator.rb
@@ -1,5 +1,6 @@
 class ApplicationDecorator
   include Deckorator::Delegator
+  include Deckorator::Undecorator
 
   attr_accessor :decorated_object
   cattr_accessor :decorated_object_class

--- a/spec/deckorator_spec.rb
+++ b/spec/deckorator_spec.rb
@@ -48,4 +48,18 @@ describe Deckorator do
       end
     end
   end
+
+  describe '#undecorate' do
+    let(:controller) { FakeController.new }
+    let(:object) { Post.new('Testing 1 2 3') }
+    let(:decorated) { PostDecorator.new(object) }
+
+    context 'when called on the decorated object' do
+      it { expect(decorated.undecorate).to eq(object) }
+    end
+
+    context 'when called from the controller' do
+      it { expect(controller.undecorate(decorated)).to eq(object) }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 
 class ApplicationDecorator
   include Deckorator::Delegator
+  include Deckorator::Undecorator
 
   attr_accessor :decorated_object
   cattr_accessor :decorated_object_class
@@ -51,7 +52,7 @@ class FakeController
 end
 
 class Post < Struct.new(:text); end
-class PostDecorator < Struct.new(:post)
+class PostDecorator < ApplicationDecorator
   def display_text; "Bang! #{post.text}"; end
 
   def comments


### PR DESCRIPTION
This adds an undecorate method for decorated objects
and controller/view methods. This will add an easier
way to grab the decorated_object which can be used
for current operations that aren't currently supported
like content_tag_for, etc.

***

Closes #25
Related #26, #31